### PR TITLE
swapped order of appending select element

### DIFF
--- a/src/jquery.selectskin.js
+++ b/src/jquery.selectskin.js
@@ -45,11 +45,11 @@
 
     SelectSkin.prototype = {
         _createDOM : function() {
-            this.select.after(this.wrapper);
-            this.select.appendTo(this.wrapper);
             this.textClip.append(this.text);
             this.mask.append(this.textClip);
             this.wrapper.append(this.mask);
+            this.select.after(this.wrapper);
+            this.select.appendTo(this.wrapper);
         },
 
         _setStyles: function() {


### PR DESCRIPTION
Hello & thanks for writing this plugin!

We used it recently on a project and got some bug reports because people were trying to click a down arrow that was on-top (z-index-wise) of the select element, blocking the interaction. Here's a screenshot for reference:
http://imgur.com/XSRx40H

While this could be solved with applying a z-index in CSS, I figured it was better to just swap the append order in the plugin so that the select element is "on top" by default.

This has worked well for us... take it or leave it!

Thanks,
- Tyler

git comment: swapped order of appending select element, so that it is on top of the mask/skin by default
